### PR TITLE
Use a consistent whitespace definition (#9)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -130,16 +130,18 @@ To <dfn export type="abstract-op">parse an origin-bound one-time code message</d
 1. Let |line| be the [=last line=] of |message|, and |position| be 0.
 1. If the code point at |position| within |line| is not U+0040 (@), return failure.
 1. Advance |position| by 1.
-1. Let |host| be the result of [=collecting a sequence of code points=] which are not [=ASCII whitespace=] from |line| with |position|.
+1. Let |host| be the result of [=collecting a sequence of code points=] which are not [=whitespace=] from |line| with |position|.
 1. If |host| is the empty string, return failure.
 1. If |host| is not a [=valid domain string=], a [=valid IPv4-address string=], or a [=valid IPv6-address string=], return failure.
-1. If the code point at |position| within |line| is not U+0020 (SPACE), return failure.
+1. If the code point at |position| within |line| is not [=whitespace=], return failure.
 1. Advance |position| by 1.
 1. If the code point at |position| within |line| is not U+0023 (#), return failure.
 1. Advance |position| by 1.
-1. Let |code| be the result of [=collecting a sequence of code points=] which are not [=ASCII whitespace=] from |line| with |position|.
+1. Let |code| be the result of [=collecting a sequence of code points=] which are not [=whitespace=] from |line| with |position|.
 1. If |code| is the empty string, return failure.
 1. Return the [=origin-bound one-time code=] ((`"https"`, |host|, `null`, `null`), |code|).
+
+The <dfn type=abstract-op>whitespace</dfn> is either U+0020 (SPACE) or U+0009 (TAB).
 
 The <dfn type=abstract-op>last line</dfn> of |string| is the result of running these steps:
 

--- a/index.html
+++ b/index.html
@@ -1224,7 +1224,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version eb52c04d, updated Fri Mar 20 17:26:11 2020 -0700" name="generator">
   <link href="https://wicg.github.io/sms-one-time-codes/" rel="canonical">
-  <meta content="22b6cfbac093005327af353dbadbe6d9bb368047" name="document-revision">
+  <meta content="1a62a05b30ac57b192df6aa5f2102553d69482b8" name="document-revision">
 <style>/* style-autolinks */
 
 .css.css, .property.property, .descriptor.descriptor {
@@ -1413,7 +1413,7 @@ dfn > a.self-link::before      { content: "#"; }</style>
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">Origin-bound one-time codes delivered via SMS</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-06-15">15 June 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-07-09">9 July 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1548,13 +1548,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li data-md>
      <p>Advance <var>position</var> by 1.</p>
     <li data-md>
-     <p>Let <var>host</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace">ASCII whitespace</a> from <var>line</var> with <var>position</var>.</p>
+     <p>Let <var>host</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points">collecting a sequence of code points</a> which are not <a data-link-type="dfn" href="#whitespace" id="ref-for-whitespace">whitespace</a> from <var>line</var> with <var>position</var>.</p>
     <li data-md>
      <p>If <var>host</var> is the empty string, return failure.</p>
     <li data-md>
-     <p>If <var>host</var> is not a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#valid-domain-string" id="ref-for-valid-domain-string">valid domain string</a> or a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#valid-ipv4-address-string" id="ref-for-valid-ipv4-address-string">valid IPv4-address string</a> or a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#valid-ipv6-address-string" id="ref-for-valid-ipv6-address-string">valid IPv6-address string</a>, return failure.</p>
+     <p>If <var>host</var> is not a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#valid-domain-string" id="ref-for-valid-domain-string">valid domain string</a>, a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#valid-ipv4-address-string" id="ref-for-valid-ipv4-address-string">valid IPv4-address string</a>, or a <a data-link-type="dfn" href="https://url.spec.whatwg.org/#valid-ipv6-address-string" id="ref-for-valid-ipv6-address-string">valid IPv6-address string</a>, return failure.</p>
     <li data-md>
-     <p>If the code point at <var>position</var> within <var>line</var> is not U+0020 (SPACE), return failure.</p>
+     <p>If the code point at <var>position</var> within <var>line</var> is not <a data-link-type="dfn" href="#whitespace" id="ref-for-whitespace①">whitespace</a>, return failure.</p>
     <li data-md>
      <p>Advance <var>position</var> by 1.</p>
     <li data-md>
@@ -1562,12 +1562,13 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li data-md>
      <p>Advance <var>position</var> by 1.</p>
     <li data-md>
-     <p>Let <var>code</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points①">collecting a sequence of code points</a> which are not <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-whitespace" id="ref-for-ascii-whitespace①">ASCII whitespace</a> from <var>line</var> with <var>position</var>.</p>
+     <p>Let <var>code</var> be the result of <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#collect-a-sequence-of-code-points" id="ref-for-collect-a-sequence-of-code-points①">collecting a sequence of code points</a> which are not <a data-link-type="dfn" href="#whitespace" id="ref-for-whitespace②">whitespace</a> from <var>line</var> with <var>position</var>.</p>
     <li data-md>
      <p>If <var>code</var> is the empty string, return failure.</p>
     <li data-md>
      <p>Return the <a data-link-type="dfn" href="#origin-bound-one-time-code" id="ref-for-origin-bound-one-time-code①⑤">origin-bound one-time code</a> ((<code>"https"</code>, <var>host</var>, <code>null</code>, <code>null</code>), <var>code</var>).</p>
    </ol>
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="whitespace" type="abstract-op">whitespace</dfn> is either U+0020 (SPACE) or U+0009 (TAB).</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="last-line" type="abstract-op">last line</dfn> of <var>string</var> is the result of running these steps:</p>
    <ol>
     <li data-md>
@@ -1753,6 +1754,7 @@ for their valuable feedback on this proposal.</p>
    <li><a href="#origin-bound-one-time-code">origin-bound one-time code</a><span>, in §2</span>
    <li><a href="#origin-bound-one-time-code-message">origin-bound one-time code message</a><span>, in §3</span>
    <li><a href="#parse-an-origin-bound-one-time-code-message">parse an origin-bound one-time code message</a><span>, in §3.2</span>
+   <li><a href="#whitespace">whitespace</a><span>, in §3.2</span>
   </ul>
   <aside class="dfn-panel" data-for="term-for-active-document">
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
@@ -1776,12 +1778,6 @@ for their valuable feedback on this proposal.</p>
    <a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-top-level-browsing-context">2.1. Usage</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-ascii-whitespace">
-   <a href="https://infra.spec.whatwg.org/#ascii-whitespace">https://infra.spec.whatwg.org/#ascii-whitespace</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-ascii-whitespace">3.2. Parsing</a> <a href="#ref-for-ascii-whitespace①">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-collect-a-sequence-of-code-points">
@@ -1866,7 +1862,6 @@ for their valuable feedback on this proposal.</p>
    <li>
     <a data-link-type="biblio">[INFRA]</a> defines the following terms:
     <ul>
-     <li><span class="dfn-paneled" id="term-for-ascii-whitespace" style="color:initial">ascii whitespace</span>
      <li><span class="dfn-paneled" id="term-for-collect-a-sequence-of-code-points" style="color:initial">collecting a sequence of code points</span>
      <li><span class="dfn-paneled" id="term-for-normalize-newlines" style="color:initial">normalize newlines</span>
      <li><span class="dfn-paneled" id="term-for-strictly-split" style="color:initial">strictly split a string</span>
@@ -1954,6 +1949,12 @@ for their valuable feedback on this proposal.</p>
    <b><a href="#parse-an-origin-bound-one-time-code-message">#parse-an-origin-bound-one-time-code-message</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-parse-an-origin-bound-one-time-code-message">3. Message format</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="whitespace">
+   <b><a href="#whitespace">#whitespace</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-whitespace">3.2. Parsing</a> <a href="#ref-for-whitespace①">(2)</a> <a href="#ref-for-whitespace②">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="last-line">


### PR DESCRIPTION
Use a consistent whitespace definition in the parsing algorithm.

The whitespace is either a SPACE or a TAB.
This PR does not relax the constraint of a single whitespace that was
also mention in #9 