### PR TITLE
update hober's pr with at sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ In this example,
 
 The characters `"@"` and `"#"` identify the origin and the code, respectively. (We can always introduce additional prefix characters in the future if it turns out we need to include additional information in these messages.)
 
-Some sites use third-party `iframe`s for authentication. In such cases, the third-party `iframe`'s origin can be specified using a `"%"` field after the code.
+Some sites use third-party `iframe`s for authentication. In such cases, the third-party `iframe`'s origin can be specified using the same `"@"` field after the code.
 
 ```text
 747723 is your ExampleCo authentication code.
 
-@example.com #747723 %ecommerce.example
+@example.com #747723 @ecommerce.example
 ```
 
 In this example,

--- a/index.bs
+++ b/index.bs
@@ -11,7 +11,6 @@ Editor: Sam Goto, Google https://google.com, goto@google.com
 Abstract: This specification defines a way to format SMS messages for use with browser autofill features such as HTML's autocomplete=one-time-code.
 Markup Shorthands: markdown yes, css no
 Complain About: accidental-2119 true
-Remove Multiple Links: yes
 </pre>
 
 <pre class="link-defaults">
@@ -87,7 +86,7 @@ User Agents determine whether or not to assist the user to provide an origin-bou
 
 If the above steps returned `"origin"` or `"site"`, the User Agent may assist the user with providing the [=origin-bound one-time code=]'s code to the website.
 
-If the above steps returned `"site"`, it might be prudent to indicate the [=origin-bound one-time code=]'s top-level and embedded origins to the user when assisting them.
+If the above steps returned `"site"`, the User Agent should indicate the [=origin-bound one-time code=]'s top-level and embedded origins to the user when assisting them.
 
 If the above steps returned failure, the User Agent should not assist the user with providing the [=origin-bound one-time code=]'s code to the website.
 
@@ -104,7 +103,7 @@ An <dfn export>origin-bound one-time code message</dfn> is a [=string=] for whic
 
 <em>This section is non-normative. [[#parsing]] is the normative text.</em>
 
-[=Origin-bound one-time code messages=] can optionally begin with human-readable <dfn for="origin-bound one-time code message">explanatory text</dfn>. This consists of all but the last line of the message. The last line of the message contains both a <dfn for="origin-bound one-time code message">top-level host</dfn> and a <dfn for="origin-bound one-time code message">code</dfn>, each prefixed with a sigil: U+0040 (@) before the [=origin-bound one-time code message/top-level host=], and U+0023 (#) before the [=code=]. Following the [=code=], an <dfn for="origin-bound one-time code message">embedded host</dfn> can be specified. It is preceeded with a U+0025 (%) sigil.
+[=Origin-bound one-time code messages=] can optionally begin with human-readable <dfn for="origin-bound one-time code message">explanatory text</dfn>. This consists of all but the last line of the message. The last line of the message contains both a <dfn for="origin-bound one-time code message">top-level host</dfn> and a <dfn for="origin-bound one-time code message">code</dfn>, each prefixed with a sigil: U+0040 (@) before the [=origin-bound one-time code message/top-level host=], and U+0023 (#) before the [=code=]. Following the [=code=], an <dfn for="origin-bound one-time code message">embedded host</dfn> can be specified. It is preceeded with a U+0040 (@) sigil.
 
 <div class="example">
 
@@ -125,7 +124,7 @@ In the following [=origin-bound one-time code message=], the [=origin-bound one-
 ```
 "747723 is your ExampleCo authentication code.
 
-@example.com #747723 %ecommerce.example"
+@example.com #747723 @ecommerce.example"
 ```
 
 </div>
@@ -140,7 +139,7 @@ The message `"something @example.com #747723"` is not an [=origin-bound one-time
 
 <div class="example">
 
-The message `"#747723 %ecommerce.example @example.com"` is not an [=origin-bound one-time code message=], because the fields are in the wrong order.
+The message `"#747723 @ecommerce.example @example.com"` is not an [=origin-bound one-time code message=], because the fields are in the wrong order.
 
 </div>
 
@@ -156,7 +155,7 @@ Trailing text in the last line is ignored. This is because we might identify add
 
 <div class="example">
 
-In the [=origin-bound one-time code message=] `"@example.com #747723 %ecommerce.example $future"`, the [=origin-bound one-time code message/top-level host=] is `"example.com"`, the [=code=] is `"747723"`, the [=origin-bound one-time code message/embedded host=] is `"ecommerce.example"`, and the [=explanatory text=] is `""`. The trailing text `" $future"` is ignored.
+In the [=origin-bound one-time code message=] `"@example.com #747723 @ecommerce.example $future"`, the [=origin-bound one-time code message/top-level host=] is `"example.com"`, the [=code=] is `"747723"`, the [=origin-bound one-time code message/embedded host=] is `"ecommerce.example"`, and the [=explanatory text=] is `""`. The trailing text `" %future"` is ignored.
 
 </div>
 
@@ -180,7 +179,7 @@ To <dfn export type="abstract-op">parse an origin-bound one-time code message</d
 1. Let |embedded origin| be null.
 1. If |position| does not point past the end of |line|, and if the [=code point=] at |position| within |line| is U+0020 (SPACE), run the following steps:
     1. Advance |position| by 1.
-    1. Let |embedded host| be the result of [=extract a marked token|extracting a marked token=] from |line| at |position| with marker U+0025 (%).
+    1. Let |embedded host| be the result of [=extract a marked token|extracting a marked token=] from |line| at |position| with marker U+0040 (@).
     1. If |embedded host| is failure, set |embedded origin| to null. Otherwise, set |embedded origin| to the [=/origin=] (`"https"`, |embedded host|, `null`, `null`).
 1. Return the [=origin-bound one-time code=] (|top-level origin|, |embedded origin|, |code|).
 
@@ -218,6 +217,7 @@ On some platforms, User Agents might need access to all incoming SMS messages—
 
 Many thanks to
 Aaron Parecki,
+Elaine Knight,
 Eric Shepherd,
 Eryn Wells,
 Jay Mulani,


### PR DESCRIPTION
[Changes](https://github.com/WICG/sms-one-time-codes/compare/nested-iframes...yi-gu:nested-iframes-with-atsign) in this PR compared to hober's [original one](https://github.com/WICG/sms-one-time-codes/pull/5):
1. As we agreed on [this thread](https://github.com/WICG/sms-one-time-codes/issues/4#issuecomment-761281590), it updates the format to use `@` instead of `%`.
2. Use stronger word to indicate that UA should notify users of the embedded frames

